### PR TITLE
Suspension

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,10 @@ curl -H "Content-type: application/json" \
 Blocks are implemented as classes with the following structure:
 
 ```python
-class MyWorkflowBlock:
+from blocks.block import WorkflowBlock
+
+
+class MyWorkflowBlock(WorkflowBlock):
     
     def get_info(self):
         """

--- a/README.md
+++ b/README.md
@@ -99,7 +99,9 @@ This is done by returning the result of the `suspend` method (inherited from `Wo
 passed to the method when suspending. This dictionary should include all parameters need to resume execution,
 including information about at what point the execution was suspended, and any parameters originally passed passed to 
 the `execute` function that are required upon resuming. This could be as simple as passing the original `params`
-dictionary, or more complex.
+dictionary, or more complex. If additional parameters should be provided by the user upon resuming execution, these
+should be requested by passing a dictionary as the `requested_params` argument. This has the same format as the `params`
+item in the block information dictionary.
 
 Upon resumption, the resume method of the block will be called. This method takes two parameters: `state`, which is the
 same dictionary as given to the `suspend` method, and `params`, which contains any new parameters. The `resume` method
@@ -111,7 +113,13 @@ example.
 def execute(self, params):
     # ... Initial code here ...
     if need_additional_data:
-        return self.suspend(params)
+        requested_params = {
+            'new_param': {
+                'type': 'string',
+                'description': 'A new parameter that we did not originally request.'
+            }
+        }
+        return self.suspend(params, requested_params)
     return result
 
 def resume(self, state, params):

--- a/src/blocks/block.py
+++ b/src/blocks/block.py
@@ -1,0 +1,15 @@
+
+
+class WorkflowBlock:
+
+    def get_info(self):
+        """
+        Returns a dictionary specifying behaviour of the block, as well as input parameters and outputs.
+        """
+        pass
+
+    def execute(self, params):
+        """
+        Implements the functionality of the block. Called by the server upon requests to the block's endpoint.
+        """
+        pass

--- a/src/blocks/block.py
+++ b/src/blocks/block.py
@@ -13,3 +13,12 @@ class WorkflowBlock:
         Implements the functionality of the block. Called by the server upon requests to the block's endpoint.
         """
         pass
+
+    def suspend(self, state):
+        """
+        Creates a suspend response, signalling that the block will wait for further input before resuming.
+        :param state: A dictionary containing all information the block will need to resume execution when called again.
+        :return: A tuple (state, status), where status will be 'suspend', to signal that the block is suspending.
+        """
+
+        return state, 'suspend'

--- a/src/blocks/block.py
+++ b/src/blocks/block.py
@@ -22,3 +22,11 @@ class WorkflowBlock:
         """
 
         return state, 'suspend'
+
+    def resume(self, state, params):
+        """
+        Resumes execution of a suspended block.
+        :param state: The state dictionary returned by the block upon suspension.
+        :param params: Any new parameters given upon resumption.
+        """
+        pass

--- a/src/blocks/block.py
+++ b/src/blocks/block.py
@@ -14,13 +14,15 @@ class WorkflowBlock:
         """
         pass
 
-    def suspend(self, state):
+    def suspend(self, state, requested_params={}):
         """
         Creates a suspend response, signalling that the block will wait for further input before resuming.
         :param state: A dictionary containing all information the block will need to resume execution when called again.
+        :param requested_params: A dictionary containing parameters that should be provided by the user upon
+                                resuming execution. Given in same format as in get_info.
         :return: A tuple (state, status), where status will be 'suspend', to signal that the block is suspending.
         """
-
+        state['requested_params'] = requested_params
         return state, 'suspend'
 
     def resume(self, state, params):

--- a/src/blocks/example.py
+++ b/src/blocks/example.py
@@ -31,7 +31,8 @@ class Example(WorkflowBlock):
 
     def execute(self, params):
         if params['param1'] == 'suspend':
-            return self.suspend({'params': params, 'suspend_count': 1})
+            return self.suspend({'params': params, 'suspend_count': 1},
+                                {'param1': {'type': 'string', 'description': 'The first parameter.'}})
 
         return {
             'output1': 'Hello',
@@ -40,6 +41,10 @@ class Example(WorkflowBlock):
 
     def resume(self, state, params):
         suspend_count = state['suspend_count'] + 1
+
+        if params['param1'] == 'suspend':
+            return self.suspend({'params': params, 'suspend_count': suspend_count},
+                                {'param1': {'type': 'string', 'description': 'The first parameter.'}})
 
         return {
             'output1': 'Hello',

--- a/src/blocks/example.py
+++ b/src/blocks/example.py
@@ -1,6 +1,7 @@
+from blocks.block import WorkflowBlock
 
 
-class Example:
+class Example(WorkflowBlock):
 
     def get_info(self):
         return {

--- a/src/blocks/example.py
+++ b/src/blocks/example.py
@@ -30,6 +30,17 @@ class Example(WorkflowBlock):
         }
 
     def execute(self, params):
+        if params['param1'] == 'suspend':
+            return self.suspend({'params': params, 'suspend_count': 1})
+
+        return {
+            'output1': 'Hello',
+            'output2': 'world!'
+        }
+
+    def resume(self, state, params):
+        suspend_count = state['suspend_count'] + 1
+
         return {
             'output1': 'Hello',
             'output2': 'world!'

--- a/src/main.py
+++ b/src/main.py
@@ -41,8 +41,10 @@ def get_block_info(block_name):
 
 
 @app.route('/<block_name>', methods=['POST'])
+@app.route('/<block_name>/resume', methods=['POST'])
 def execute_block(block_name):
     body = request.get_json()
+    is_resuming = request.path.endswith('/resume')
 
     try:
         block = block_manager.blocks[block_name]
@@ -61,7 +63,12 @@ def execute_block(block_name):
 
         cleaned_params[name] = body['params'][name]
 
-    result = block.execute(cleaned_params)
+    if is_resuming:
+        # TODO State validation?
+        result = block.resume(body['state'], cleaned_params)
+    else:
+        result = block.execute(cleaned_params)
+
 
     if type(result) == dict:
         response = {

--- a/src/main.py
+++ b/src/main.py
@@ -49,6 +49,9 @@ def execute_block(block_name):
     except KeyError:
         return 'No block with that name exists.', 404
 
+    # Create new dictionary that will only contain parameters included in block specification
+    cleaned_params = {}
+
     for name, param in block.get_info()['params'].items():
         if name not in body['params']:
             return 'Missing parameter ' + name + ".", 400
@@ -56,9 +59,26 @@ def execute_block(block_name):
         if type(body['params'][name]) != block_manager.type_map[param['type']]:
             return 'Invalid type for parameter ' + name + "; expected " + param['type'] + ".", 400
 
-    result = block.execute(body['params'])
+        cleaned_params[name] = body['params'][name]
 
-    return jsonify(result)
+    result = block.execute(cleaned_params)
+
+    if type(result) == dict:
+        response = {
+            'type': 'result',
+            'data': result
+        }
+    elif type(result) == tuple:
+        status = result[1]
+        if status == 'suspend':
+            response = {
+                'type': 'suspend',
+                'state': result[0]
+            }
+    else:
+        return 'Workflow block returned invalid data.', 500
+
+    return jsonify(response)
 
 
 # Only for testing purposes - should use WSGI server in production

--- a/src/tests/test_example_block.py
+++ b/src/tests/test_example_block.py
@@ -1,0 +1,74 @@
+import unittest
+
+import block_manager
+from main import app
+
+example_input = {'params': {'param1': 'test', 'param2': 1}}
+example_suspend = {'params': {'param1': 'suspend', 'param2': 1}}
+
+
+
+class ExampleTests(unittest.TestCase):
+
+    def setUp(self):
+        self.blocks = block_manager.blocks
+        self.app = app.test_client()
+
+    def execute_example(self, param1=None, param2=None):
+        input = {'params': {}}
+        if param1 is not None:
+            input['params']['param1'] = param1
+        if param2 is not None:
+            input['params']['param2'] = param2
+        return self.app.post('/example', json = input)
+
+
+    def test_discovery(self):
+        response = self.app.get('/discovery')
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b'An example block used for documentation', response.data)
+
+    def test_all_blocks_are_discovered(self):
+        response = self.app.get('/discovery')
+        data = response.get_json()
+        self.assertEqual(len(data['blocks']), len(self.blocks))
+        self.assertEqual(response.status_code, 200)
+
+    def test_example_execution(self):
+        response = self.execute_example('test', 1)
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b'Hello', response.data)
+        self.assertIn(b'world', response.data)
+
+    def test_missing_param(self):
+        response = self.execute_example('test_missing_param2')
+        self.assertEqual(response.status_code, 400)
+        self.assertIn(b'Missing parameter param2', response.data)
+
+    def test_wrong_param_type(self):
+        response = self.execute_example(1, 1)
+        self.assertEqual(response.status_code, 400)
+        self.assertIn(b'Invalid type for parameter param1', response.data)
+
+        response = self.execute_example('test', 'string_not_integer')
+        self.assertEqual(response.status_code, 400)
+        self.assertIn(b'Invalid type for parameter param2', response.data)
+
+    def test_example_suspension(self):
+        response = self.execute_example('suspend', 1)
+        resp_data = response.get_json()
+        susp_count = resp_data['state']['suspend_count']
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(susp_count, 1)
+        self.assertIn(b'state', response.data)
+        self.assertIn(b'requested_params', response.data)
+        self.assertIn(b'"type":"suspend"', response.data)
+
+    def test_example_resuming(self):
+        suspend_response = self.execute_example('suspend', 1)
+        self.assertEqual(suspend_response.status_code, 200)
+        data = suspend_response.get_json()
+        data['params'] = {'param1': 'test_resume'}
+        resume_response = self.app.post('/example/resume', json=data)
+        self.assertEqual(resume_response.status_code, 200)
+


### PR DESCRIPTION
Adds APIs for suspending the execution of a block. This works by sending a special response to the requesting service, which contains the current state of the block, along with a request for any required additional parameters. Upon resumption, the state is passed back to the block along with the new parameters.